### PR TITLE
do nan check on float parsing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -105,7 +105,6 @@
         // we use JSCS, set most to off because they're on by default.
         // turn the few on that aren't handled by JSCS today.
         "camelcase": [ 0 ],
-        "comma-dangle": [ 0 ],
         "key-spacing": [ 0 ],
         "no-lonely-if": [ 0 ],
         "no-multi-str": [ 0 ],

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ codestyle-fix: node_modules $(ALL_FILES)
 .PHONY: nsp
 nsp: node_modules $(ALL_FILES)
 	@$(NPM) shrinkwrap --dev
-	@($(NSP) audit-shrinkwrap || echo 1) | $(NSP_BADGE)
+	@($(NSP) check) | $(NSP_BADGE)
 	@rm $(SHRINKWRAP)
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -114,7 +114,7 @@ function parseJson(data, options) {
             if (opt.float === true) {
                 parsed = parseFloat(val);
 
-                if (parsed.toString().length === val.length) {
+                if (parsed.toString().length === val.length && !isNaN(parsed)) {
                     acc[key] = parsed;
                 }
             }
@@ -133,7 +133,6 @@ function parseJson(data, options) {
                     }
                 }
             }
-
         }
 
         // if by this point we don't have a value, use the existing value

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   ],
   "devDependencies": {
     "chai": "^3.3.0",
-    "coveralls": "^2.11.4",
-    "eslint": "^1.5.0",
-    "istanbul": "^0.3.21",
+    "coveralls": "^2.11.9",
+    "eslint": "^2.10.2",
+    "istanbul": "^0.4.3",
     "jscs": "^2.1.1",
     "mocha": "^2.3.3",
-    "nsp": "^1.1.0"
+    "nsp": "^2.4.0"
   },
   "scripts": {
     "test": "make test",
@@ -36,7 +36,7 @@
     "report": "make report-coverage"
   },
   "dependencies": {
-    "lodash": "^3.9.3",
+    "lodash": "^3.10.1",
     "safe-json-parse": "^4.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,8 @@ describe('lame-json node module.', function() {
         qux: [ 1, 2, 3 ],
         xul: '1.2.3',
         zub: 45.66,
-        buz: '1e6'
+        buz: '1e6',
+        fooString: 'foo'
     };
     var stringData = {
         foo: 'true',
@@ -30,7 +31,8 @@ describe('lame-json node module.', function() {
         qux: '[1, 2, 3]',
         xul: '1.2.3',
         zub: '45.66',
-        buz: '1e6'
+        buz: '1e6',
+        fooString: 'foo'
     };
 
     it('should return JSON object as is', function() {

--- a/tools/nspBadge.js
+++ b/tools/nspBadge.js
@@ -17,6 +17,7 @@ process.stdin.on('data', function(exitCodeBuf) {
     var nspExitCode = parseInt(exitCodeBuf.toString(), 10);
 
     if (isNaN(nspExitCode)) {
+        console.warn(exitCodeBuf.toString()); // eslint-disable-line no-console
         nspExitCode = 0;
     }
 


### PR DESCRIPTION
@micahr @jdarren @betaorbust

Fixes corner case where a value of 'foo' would get saved as 'NaN' because the length was identical. Affects only 3 letter strings.